### PR TITLE
Fixes for (non-)concrete types in about(type)

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -13,14 +13,18 @@ end
 
 function structinfo(T::Type)
     map(1:fieldcount(T)) do i
-        if hassizeof(T) && hassizeof(fieldtype(T, i))
+        if hassizeof(T)
             offset = fieldoffset(T, i) |> Int
             size = Int(if i < fieldcount(T)
                            fieldoffset(T, i+1)
                     else
                            sizeof(T)
                     end - fieldoffset(T, i))
-            contentsize = sizeof(fieldtype(T, i))
+            contentsize = if hassizeof(fieldtype(T, i))
+                sizeof(fieldtype(T, i))
+            else
+                0
+            end
             if contentsize > size # Pointer?
                 contentsize = 0
             end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -10,6 +10,12 @@ function humansize(bytes::Integer)
     end, units[1+magnitude]
 end
 
+function hassizeof(type::Type)
+    !isconcretetype(type) && return false
+    type in (Symbol, String, Core.SimpleVector) && return false
+    true
+end
+
 function cpad(s, n::Integer, pad::Union{AbstractString, AbstractChar}=' ', r::RoundingMode = RoundToZero)
     rpad(lpad(s, div(n+textwidth(s), 2, r), pad), n, pad)
 end


### PR DESCRIPTION
Basically two small fixes:

- support non-concrete types:
```julia
julia> about(Array)
UnionAll defined in Core, 
  Array <: DenseArray <: AbstractArray <: Any

Struct with 2 fields:
• ref::MemoryRef                
• size::NTuple{N, Int64} where N
```

- Support concrete types that have no `sizeof` (`Symbol`, `String`, ...). 
Note: my `hassizeof` is not fully correct, for example, it's wrong for `Ptr` and `Val`. Maybe I need some other abstraction to handle this reliably (or just try catch as it was before).

