### PR TITLE
Basic support for `about(::Module)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,8 +5,10 @@ version = "0.1.0"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 StyledStrings = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
 
 [compat]
 InteractiveUtils = "1.11.0"
+Pkg = "1.12.0"
 StyledStrings = "1.11.0"

--- a/src/About.jl
+++ b/src/About.jl
@@ -2,6 +2,7 @@ module About
 
 using Base: AnnotatedString, AnnotatedIOBuffer
 using StyledStrings: @styled_str, Face, face!
+using Pkg: dependencies
 using InteractiveUtils
 
 export about
@@ -10,10 +11,12 @@ include("utils.jl")
 include("functions.jl")
 include("types.jl")
 include("values.jl")
+include("modules.jl")
 
 """
     about(fn::Function, [signature::Tuple])
     about(typ::Type)
+    about(mod::Module)
     about(obj::Any)
 
 Display information on the particular nature of the argument, whether

--- a/src/modules.jl
+++ b/src/modules.jl
@@ -1,0 +1,42 @@
+function about(io::IO, mod::Module)
+    print(io, Base.summary(mod), " ", styled"{bright_red:$mod}")
+    pkg = Base.identify_package(string(mod))
+    # if is a package
+    if !isnothing(pkg)
+        println(io, styled" {shadow:[$(pkg.uuid)]}")
+        deps = dependencies()
+        idx = findfirst(pkginfo -> pkginfo.name == string(mod), collect(values(deps)))
+        pkginfo = collect(values(deps))[idx]
+        if !isnothing(pkgversion(mod))
+            if isnothing(pkginfo.version)
+                print(io, styled"  {bright_red:Standard library}")
+            else
+                print(io, styled"  Version {bright_red:$(pkgversion(mod))}")
+            end
+        end
+        if !isnothing(pkgdir(mod))
+            println(io, styled" loaded from {bright_blue:$(pkgdir(mod))}\n")
+        end
+        print_dependencies(io, mod)
+    else
+        println(io)
+    end
+    println(io)
+    print_names(io, mod)
+end
+
+function print_dependencies(io::IO, mod::Module)
+    deps = dependencies()
+    idx = findfirst(pkg -> pkg.name == string(mod), collect(values(deps)))
+    isnothing(idx) && return
+    pkg = collect(values(deps))[idx]
+    println(io, styled"Depends directly on {bright_blue:$(length(pkg.dependencies))} packages:")
+    pkgdeps = sort(map(string, collect(keys(pkg.dependencies))))
+    columnlist(io, pkgdeps)
+end
+
+function print_names(io::IO, mod::Module)
+    println(io, styled"Exports {bright_blue:$(length(names(mod)))} names:")
+    pkgnames = map(string, names(mod))
+    columnlist(io, pkgnames)
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -38,12 +38,12 @@ function columnlist(io::IO, entries::Vector{<:AbstractString};
     thecolwidths = Int[]
     for ncols in 1:maxcols
         columns = Vector{eltype(entries)}[]
-        for col in Iterators.partition(entries, length(entries) ÷ ncols)
+        for col in Iterators.partition(entries, div(length(entries), ncols, RoundUp))
             push!(columns, collect(col))
         end
         widths = map.(textwidth, columns)
         colwidths = map(maximum, widths)
-        if sum(colwidths) + ncols * textwidth(prefix) + (1 - ncols) * spacing > maxwidth
+        if sum(colwidths) + ncols * textwidth(prefix) + (ncols - 1) * spacing > maxwidth
             break
         else
             thecolumns, thecolwidths = columns, colwidths


### PR DESCRIPTION
Prints some basics in `about(::Module)`:

<img width="597" alt="image" src="https://github.com/tecosaur/About.jl/assets/60229118/8942a308-1ff7-410b-80a1-00704bdde9ea">

Two notes:

- I am not sure how useful are the dependencies and the exported names. I added it for now just to try it out.

- Maybe there is some other compact and useful info about a module that can be printed in the header... Any ideas ?

Also this pr fixes a bug in `columnlist`.
