### PR TITLE
Tweak floating point zeros and subnormals

### DIFF
--- a/src/values.jl
+++ b/src/values.jl
@@ -273,10 +273,14 @@ function floatlayout(io::IO, float::AbstractFloat, expbits::Int)
         fraction = reinterpret(Float64, bits & Base.Ryu.MANTISSA_MASK | 0x3ff0000000000000)
         expstr = cpad(if exponent == 1024
                           "Inf"
+                      elseif exponent <= -maxexp
+                          "2^$(-maxexp + 1)"
                       else "2^$exponent" end,
                       expbits - 1, ' ', RoundUp)
         fracstr = cpad(if exponent == 1024
                            ifelse(fraction == 1.0, "1", "NaN")
+                       elseif exponent <= -maxexp
+                           Base.Ryu.writefixed(float / floatmin(float), fracdp + 2)
                        else
                            Base.Ryu.writefixed(fraction, fracdp + 2)
                        end, fracbits, ' ', RoundUp)


### PR DESCRIPTION
Fixes #23.

Examples of new output:
```
julia> about(0.0)
Float64 (<: AbstractFloat <: Real <: Number <: Any), occupies 8B.

 0000000000000000000000000000000000000000000000000000000000000000 
 ╨└────┬────┘└────────────────────────┬─────────────────────────┘
 +  2^-1022 ×                0.000000000000000000                
 = 0.0000000000000000e+00

julia> about(nextfloat(0.0))
Float64 (<: AbstractFloat <: Real <: Number <: Any), occupies 8B.

 0000000000000000000000000000000000000000000000000000000000000001 
 ╨└────┬────┘└────────────────────────┬─────────────────────────┘
 +  2^-1022 ×                0.000000000000000222                
 = 4.9406564584124654e-324

julia> about(0.0f0)
Float32 (<: AbstractFloat <: Real <: Number <: Any), occupies 4B.

 00000000000000000000000000000000 
 ╨└──┬───┘└──────────┬──────────┘
 + 2^-126×      0.000000000      
 = 0.0000000e+00

julia> about(floatmin(Float32) / 4)
Float32 (<: AbstractFloat <: Real <: Number <: Any), occupies 4B.

 00000000001000000000000000000000 
 ╨└──┬───┘└──────────┬──────────┘
 + 2^-126×      0.250000000      
 = 2.9387359e-39
```