### PR TITLE
Struct mutability

### DIFF
--- a/README.org
+++ b/README.org
@@ -63,7 +63,7 @@ julia> about(Dict{Symbol, Int})
 Concrete DataType defined in Base, 64B
   Dict{Symbol, Int64} <: AbstractDict{Symbol, Int64} <: Any
 
-Struct with 8 fields:
+Mutable struct with 8 fields:
 • slots    *Memory{UInt8}
 • keys     *Memory{Symbol}
 • vals     *Memory{Int64}

--- a/src/About.jl
+++ b/src/About.jl
@@ -70,7 +70,7 @@ julia> about(Dict{Symbol, Int})
 Concrete DataType defined in Base, 64B
   Dict{Symbol, Int64} <: AbstractDict{Symbol, Int64} <: Any
 
-Struct with 8 fields:
+Mutable struct with 8 fields:
 • slots    *Memory{UInt8}
 • keys     *Memory{Symbol}
 • vals     *Memory{Int64}

--- a/src/types.jl
+++ b/src/types.jl
@@ -84,7 +84,8 @@ function about(io::IO, type::Type)
         println(io)
         return
     end
-    print(io, S"\n\nStruct with {bold:$(fieldcount(type))} fields:")
+    mutability = ismutabletype(type) ? "Mutable" : "Immutable"
+    print(io, S"\n\n$mutability struct with {bold:$(fieldcount(type))} fields:")
     fieldinfo = AnnotatedString[]
     if type isa DataType
         sinfo = structinfo(type)


### PR DESCRIPTION
Add the mutability information to `about` of a struct `DataType`.

Note, that the output of type and value are inconsistent. After this PR it looks like:
```julia
julia> BigInt |> about
Concrete DataType defined in Base.GMP, 16B
  BigInt <: Signed <: Integer <: Real <: Number <: Any

Mutable struct with 3 fields:
• alloc  Int32      
• size   Int32      
• d      Ptr{UInt64}
 ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
        4B               4B                        8B                

julia> BigInt(12) |> about
BigInt (mutable) (<: Signed <: Integer <: Real <: Number <: Any)
 Memory footprint: 16B directly (referencing 24B in total)
 alloc::Int32       4B 00000000000000000000000000000001       1
  size::Int32       4B 00000000000000000000000000000001       1
     d::Ptr{UInt64} 8B 000000000000000000 … 10101010111000000 Ptr{UInt6 … 08b55c0)

 ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
        4B               4B                        8B
```
However, the output was already inconsistent before this PR, so it's unclear whether the additional inconsistency is relevant.

I would expect to have only two differences in the output of types and values:
- show whether we have a type or a value
- list the values in the fieldinfo for a value, but not for a type

But this is a totally different topic and not relevant for this PR.

Fixes #65 