### PR TITLE
Struct field singular plural

### DIFF
--- a/README.org
+++ b/README.org
@@ -63,7 +63,7 @@ julia> about(Dict{Symbol, Int})
 Concrete DataType defined in Base, 64B
   Dict{Symbol, Int64} <: AbstractDict{Symbol, Int64} <: Any
 
-Struct with 8 fields:
+Mutable struct with 8 fields:
 • slots    *Memory{UInt8}
 • keys     *Memory{Symbol}
 • vals     *Memory{Int64}

--- a/src/About.jl
+++ b/src/About.jl
@@ -70,7 +70,7 @@ julia> about(Dict{Symbol, Int})
 Concrete DataType defined in Base, 64B
   Dict{Symbol, Int64} <: AbstractDict{Symbol, Int64} <: Any
 
-Struct with 8 fields:
+Mutable struct with 8 fields:
 • slots    *Memory{UInt8}
 • keys     *Memory{Symbol}
 • vals     *Memory{Int64}

--- a/src/types.jl
+++ b/src/types.jl
@@ -84,7 +84,8 @@ function about(io::IO, type::Type)
         println(io)
         return
     end
-    print(io, S"\n\nStruct with {bold:$(fieldcount(type))} fields:")
+    mutability = ismutabletype(type) ? "Mutable" : "Immutable"
+    print(io, S"\n\n$mutability struct with {bold:$(fieldcount(type))} fields:")
     fieldinfo = AnnotatedString[]
     if type isa DataType
         sinfo = structinfo(type)

--- a/src/types.jl
+++ b/src/types.jl
@@ -85,7 +85,8 @@ function about(io::IO, type::Type)
         return
     end
     mutability = ismutabletype(type) ? "Mutable" : "Immutable"
-    print(io, S"\n\n$mutability struct with {bold:$(fieldcount(type))} fields:")
+    fieldstr = isone(fieldcount(type)) ? "field" : "fields"
+    print(io, S"\n\n$mutability struct with {bold:$(fieldcount(type))} $fieldstr:")
     fieldinfo = AnnotatedString[]
     if type isa DataType
         sinfo = structinfo(type)


### PR DESCRIPTION
Use singular or plural for "field" depending on how many fields we have.

This builds on top of #66, as otherwise the PR would be a complete merge conflict.